### PR TITLE
Add separate arm32v7 Dockerfile

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -69,6 +69,7 @@ module.exports = class extends Generator {
     this._copyStatic('gitignore', '.gitignore');
     this._copyStatic('app.js');
     this._copyStatic('Dockerfile');
+    this._copyStatic('Dockerfile.arm32v7');
     this._copyStatic('Dockerfile.windows-amd64');
 
     this._copyTemplate('module.json', { repository: this.repository });

--- a/app/templates/Dockerfile.arm32v7
+++ b/app/templates/Dockerfile.arm32v7
@@ -1,0 +1,15 @@
+FROM arm32v7/node:8
+
+WORKDIR /app/
+
+COPY package*.json ./
+
+RUN npm install --production
+
+COPY app.js ./
+
+USER node
+
+ENV DEBUG_OPTION " "
+
+CMD ["sh", "-c", "node $DEBUG_OPTION app.js"]

--- a/app/templates/module.json
+++ b/app/templates/module.json
@@ -7,7 +7,7 @@
             "version": "0.0.1",
             "platforms": {
                 "amd64": "./Dockerfile",
-                "arm32v7": "./Dockerfile",
+                "arm32v7": "./Dockerfile.arm32v7",
                 "windows-amd64": "./Dockerfile.windows-amd64"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-azure-iot-edge-module",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-azure-iot-edge-module",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-rc3",
   "description": "Yeoman generator for Azure IoT Edge Node module",
   "files": [
     "app"

--- a/test/assets/module.json
+++ b/test/assets/module.json
@@ -7,7 +7,7 @@
             "version": "0.0.1",
             "platforms": {
                 "amd64": "./Dockerfile",
-                "arm32v7": "./Dockerfile",
+                "arm32v7": "./Dockerfile.arm32v7",
                 "windows-amd64": "./Dockerfile.windows-amd64"
             }
         },

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -17,6 +17,7 @@ describe("generator-azure-iot-edge-module: app", function () {
                     "TestModule/.gitignore",
                     "TestModule/app.js",
                     "TestModule/Dockerfile",
+                    "TestModule/Dockerfile.arm32v7",
                     "TestModule/Dockerfile.windows-amd64",
                     "TestModule/module.json",
                     "TestModule/package.json"
@@ -38,6 +39,7 @@ describe("generator-azure-iot-edge-module: app", function () {
                     "TestModule/.gitignore",
                     "TestModule/app.js",
                     "TestModule/Dockerfile",
+                    "TestModule/Dockerfile.arm32v7",
                     "TestModule/Dockerfile.windows-amd64",
                     "TestModule/module.json",
                     "TestModule/package.json"

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -1,52 +1,52 @@
-"use strict";
+'use strict';
 
-var assert = require("yeoman-assert");
-var fs = require("fs");
-var helpers = require("yeoman-test");
-var path = require("path");
+var assert = require('yeoman-assert');
+var fs = require('fs');
+var helpers = require('yeoman-test');
+var path = require('path');
 
-describe("generator-azure-iot-edge-module: app", function () {
-    it("should generate module files with prompts", function () {
-        return helpers.run(path.join(__dirname, "../app"))
+describe('generator-azure-iot-edge-module: app', function () {
+    it('should generate module files with prompts', function () {
+        return helpers.run(path.join(__dirname, '../app'))
             .withPrompts({
-                name: "TestModule",
-                repository: "localhost:5555/TestModule"
+                name: 'TestModule',
+                repository: 'localhost:5555/TestModule'
             })
             .then(() => {
                 assert.file([
-                    "TestModule/.gitignore",
-                    "TestModule/app.js",
-                    "TestModule/Dockerfile",
-                    "TestModule/Dockerfile.arm32v7",
-                    "TestModule/Dockerfile.windows-amd64",
-                    "TestModule/module.json",
-                    "TestModule/package.json"
+                    'TestModule/.gitignore',
+                    'TestModule/app.js',
+                    'TestModule/Dockerfile',
+                    'TestModule/Dockerfile.arm32v7',
+                    'TestModule/Dockerfile.windows-amd64',
+                    'TestModule/module.json',
+                    'TestModule/package.json'
                 ]);
 
-                assert.jsonFileContent("TestModule/module.json", JSON.parse(fs.readFileSync(path.join(__dirname, "assets/module.json"), "utf-8")));
-                assert.jsonFileContent("TestModule/package.json", JSON.parse(fs.readFileSync(path.join(__dirname, "assets/package.json"), "utf-8")));
+                assert.jsonFileContent('TestModule/module.json', JSON.parse(fs.readFileSync(path.join(__dirname, 'assets/module.json'), 'utf-8')));
+                assert.jsonFileContent('TestModule/package.json', JSON.parse(fs.readFileSync(path.join(__dirname, 'assets/package.json'), 'utf-8')));
             });
     });
 
-    it("should generate module files with options", function () {
-        return helpers.run(path.join(__dirname, "../app"))
+    it('should generate module files with options', function () {
+        return helpers.run(path.join(__dirname, '../app'))
             .withOptions({
-                name: "TestModule",
-                repository: "localhost:5555/TestModule"
+                name: 'TestModule',
+                repository: 'localhost:5555/TestModule'
             })
             .then(() => {
                 assert.file([
-                    "TestModule/.gitignore",
-                    "TestModule/app.js",
-                    "TestModule/Dockerfile",
-                    "TestModule/Dockerfile.arm32v7",
-                    "TestModule/Dockerfile.windows-amd64",
-                    "TestModule/module.json",
-                    "TestModule/package.json"
+                    'TestModule/.gitignore',
+                    'TestModule/app.js',
+                    'TestModule/Dockerfile',
+                    'TestModule/Dockerfile.arm32v7',
+                    'TestModule/Dockerfile.windows-amd64',
+                    'TestModule/module.json',
+                    'TestModule/package.json'
                 ]);
 
-                assert.jsonFileContent("TestModule/module.json", JSON.parse(fs.readFileSync(path.join(__dirname, "assets/module.json"), "utf-8")));
-                assert.jsonFileContent("TestModule/package.json", JSON.parse(fs.readFileSync(path.join(__dirname, "assets/package.json"), "utf-8")));
+                assert.jsonFileContent('TestModule/module.json', JSON.parse(fs.readFileSync(path.join(__dirname, 'assets/module.json'), 'utf-8')));
+                assert.jsonFileContent('TestModule/package.json', JSON.parse(fs.readFileSync(path.join(__dirname, 'assets/package.json'), 'utf-8')));
             });
     });
 });


### PR DESCRIPTION
Without this, images built on X64 machines will not run on ARM machines. On the other hand, per my own test building ARM images now succeeded on X64 machines somehow, and we also have a report from bug bash that users have their modules built on X64 machines with explicit ARM base image run well on ARM machines.