### PR TITLE
Preserve the case of input repository

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -59,7 +59,7 @@ module.exports = class extends Generator {
       }
     ]).then((answers) => {
       this.name = (this.options.name || answers.name).trim();
-      this.repository = (this.options.repository || answers.repository).trim().toLowerCase();
+      this.repository = (this.options.repository || answers.repository).trim();
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-azure-iot-edge-module",
-  "version": "1.1.0",
+  "version": "1.2.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-azure-iot-edge-module",
-  "version": "1.1.0",
+  "version": "1.2.0-rc",
   "description": "Yeoman generator for Azure IoT Edge Node.js module",
   "files": [
     "app"

--- a/test/assets/module.json
+++ b/test/assets/module.json
@@ -2,7 +2,7 @@
     "$schema-version": "0.0.1",
     "description": "",
     "image": {
-        "repository": "localhost:5555/testmodule",
+        "repository": "localhost:5555/TestModule",
         "tag": {
             "version": "0.0.1",
             "platforms": {


### PR DESCRIPTION
The benefit of preserving the case of input repository:
1. Aligning with other languages' templates
2. On non-Windows OS, system environment variables are case sensitive. If the user add a module with `${CONTAINER_REGISTRY_SERVER}/modulename` as the image repository, converting it to lowercase will cause problems when expanding the environment variable.